### PR TITLE
Correct errors in preparation for merging

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -19,7 +19,7 @@ system "Omnis"
 	government "cheat"
 
 	object "omnis gateway"
-			sprite "sprite/wisp_red"
+			sprite "sprite/wisp_green"
 	object Plugins
 		sprite "sprite/station8"
 		distance 444
@@ -386,9 +386,11 @@ system "Omnis"
 		distance 6000
 		offset 28
 	object Peregrine
-		sprite "ship/Peregrine/Peregrine"
+		sprite "ship/peregrine/peregrine"
+			"frame rate" 3
+			"rewind"
 		distance 6000
-		offest 32
+		offset 32
 	object Starling
 		sprite "ship/starling"
 		distance 6000

--- a/data/stars.txt
+++ b/data/stars.txt
@@ -1,3 +1,3 @@
-star "sprite/wisp_red"
-	power 1
-	wind 1
+star "sprite/everything"
+	power 0.06
+	wind 0.06


### PR DESCRIPTION
Just a few issues. First, I'm not entirely confident in changing the Omnis gateway to the red wisp, rather, I have added solar and fuel collection to the sprite for Omnis ringworlds, a value that would equal roughly 1 in total.

I have also fixed an issue with the peregrine sprite definition and offset, so that it actually shows up in the arena.